### PR TITLE
[WIP]グループ作成機能の実装

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,9 +1,22 @@
 class GroupsController < ApplicationController
   
   def new
+    @group = Group.new
+    @group.users << current_user
   end
 
   def create
+    @group = Group.new(group_params)
+    if @group.save
+      redirect_to root_path, notice: 'グループを作成しました'
+    else
+      render :new
+    end
+  end
+
+  private
+  def group_params
+    params.require(:group).permit(:name, user_ids: [] )
   end
 
   def edit

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,25 +1,27 @@
 .chat-group-form
   %h1 新規チャットグループ
-  %form
-    .chat-group-form__errors
-      %h2
-        1件のエラーが発生しました。
+  = form_for @group do |f|
+    - if @group.errors.any?
+      .chat-group-form__errors
+        %h2= "#{@group.errors.full_messages.count}件のエラーが発生しました。"
         %ul
-          %li エラーです
+          - @group.errors.full_messages.each do |message|
+            %li= message
     .chat-group-form__field
       .chat-group-form__field--left
-        %label.chat-group-form__label{for: "chat_group_name"} グループ名
+        = f.label :name, class: 'chat-group-form__label'
       .chat-group-form__field--right
-        %input#chat_group_name.chat-group-form__input{name: "chat_group[name]", placeholder: "グループ名を入力してください", type: "text"}/
+        = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: "グループ名を入力してください"
     .chat-group-form__field
       / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します
     .chat-group-form__field
       .chat-group-form__field--left
-        %label.chat-group-form__label チャットメンバー
+        = f.label "チャットメンバー", class: "chat-group-form__label"
       .chat-group-form__field--right
         / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
+        = f.collection_check_boxes :user_ids, User.all, :id, :name
         / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときにも使用します
     .chat-group-form__field
       .chat-group-form__field--left
       .chat-group-form__field--right
-        %input.chat-group-form__action-btn{"data-disable-with": "Save", name: "commit", type: "submit", value: "Save"}/
+        = f.submit class: 'chat-group-form__action-btn'


### PR DESCRIPTION
# What
グループ作成機能の実装を行う。
collection_check_boxesを設置し、グループ作成成功時には、フラッシュメッセージをだす。グループの名前にはバリデーションをかける（グループ名未記載だとエラー／同じ名前のグループが作成できないようにする）。グループ作成失敗時には、errorsやerrors_full_messageを使用し、エラーメッセージを表示する。

# Why
chatspaceでグループ機能が必要だから
